### PR TITLE
Legge til river for å hente InnvilgedeVedtak

### DIFF
--- a/app/src/main/kotlin/no/nav/omsorgsdager/RapidsApplication.kt
+++ b/app/src/main/kotlin/no/nav/omsorgsdager/RapidsApplication.kt
@@ -10,6 +10,7 @@ import no.nav.omsorgsdager.midlertidigalene.InitierAvslåttMidlertidigAleneRiver
 import no.nav.omsorgsdager.midlertidigalene.InitierInnvilgetMidlertidigAleneRiver
 import no.nav.omsorgsdager.midlertidigalene.LagreAvslåttMidlertidigAleneRiver
 import no.nav.omsorgsdager.midlertidigalene.LagreInnvilgetMidlertidigAleneRiver
+import no.nav.omsorgsdager.vedtak.InnvilgedeVedtakRiver
 
 internal fun RapidsConnection.registerApplicationContext(applicationContext: ApplicationContext) {
     // Kronisk sykt barn
@@ -23,6 +24,9 @@ internal fun RapidsConnection.registerApplicationContext(applicationContext: App
     LagreInnvilgetMidlertidigAleneRiver(rapidsConnection = this, behandlingService = applicationContext.behandlingService)
     InitierAvslåttMidlertidigAleneRiver(rapidsConnection = this, personInfoGateway = applicationContext.personInfoGatway)
     LagreAvslåttMidlertidigAleneRiver(rapidsConnection = this, behandlingService = applicationContext.behandlingService)
+
+    // Hente Innvilgede Vedtak
+    InnvilgedeVedtakRiver(rapidsConnection = this, innvilgedeVedtakService = applicationContext.innvilgedeVedtakService)
 
     register(object : RapidsConnection.StatusListener {
         override fun onStartup(rapidsConnection: RapidsConnection) {

--- a/app/src/main/kotlin/no/nav/omsorgsdager/vedtak/InnvilgedeVedtakRiver.kt
+++ b/app/src/main/kotlin/no/nav/omsorgsdager/vedtak/InnvilgedeVedtakRiver.kt
@@ -1,0 +1,55 @@
+package no.nav.omsorgsdager.vedtak
+
+import kotlinx.coroutines.runBlocking
+import no.nav.helse.rapids_rivers.JsonMessage
+import no.nav.helse.rapids_rivers.RapidsConnection
+import no.nav.helse.rapids_rivers.River
+import no.nav.helse.rapids_rivers.asLocalDate
+import no.nav.k9.rapid.river.BehovssekvensPacketListener
+import no.nav.k9.rapid.river.leggTilLøsning
+import no.nav.k9.rapid.river.skalLøseBehov
+import no.nav.omsorgsdager.CorrelationId.Companion.somCorrelationId
+import no.nav.omsorgsdager.Identitetsnummer.Companion.somIdentitetsnummer
+import no.nav.omsorgsdager.Json
+import no.nav.omsorgsdager.tid.Periode
+import org.slf4j.LoggerFactory
+
+internal class InnvilgedeVedtakRiver(
+    rapidsConnection: RapidsConnection,
+    private val innvilgedeVedtakService: InnvilgedeVedtakService
+) : BehovssekvensPacketListener(logger = logger) {
+
+    init {
+        River(rapidsConnection).apply {
+            validate {
+                it.skalLøseBehov(Behov)
+                it.interestedIn(IdentitetsnummerKey, FomKey, TomKey)
+            }
+        }.register(this)
+    }
+
+    override fun handlePacket(id: String, packet: JsonMessage): Boolean {
+        logger.info("Henter innvilgede vedtak for utvidet rett.")
+        val innvilgedeVedtak = runBlocking { innvilgedeVedtakService.hentInnvilgedeVedtak(
+            identitetsnummer = packet.identietsnummer(),
+            periode = packet.periode(),
+            correlationId = packet.correlationId()
+        )}
+
+        packet.leggTilLøsning(Behov, Json(innvilgedeVedtak).map)
+
+        return true
+    }
+
+    private fun JsonMessage.periode() = Periode(fom = get(FomKey).asLocalDate(), tom = get(TomKey).asLocalDate())
+    private fun JsonMessage.identietsnummer() = get(IdentitetsnummerKey).asText().somIdentitetsnummer()
+    private fun JsonMessage.correlationId() = get("@correlationId").asText().somCorrelationId()
+
+    private companion object {
+        private const val Behov = "HentUtvidetRettVedtakV2"
+        private const val FomKey = "@behov.$Behov.fom"
+        private const val TomKey = "@behov.$Behov.tom"
+        private const val IdentitetsnummerKey = "@behov.$Behov.identitetsnummer"
+        private val logger = LoggerFactory.getLogger(InnvilgedeVedtakRiver::class.java)
+    }
+}

--- a/app/src/test/kotlin/no/nav/omsorgsdager/vedtak/InnvilgedeVedtakApisTest.kt
+++ b/app/src/test/kotlin/no/nav/omsorgsdager/vedtak/InnvilgedeVedtakApisTest.kt
@@ -2,204 +2,87 @@ package no.nav.omsorgsdager.vedtak
 
 import io.ktor.http.*
 import io.ktor.server.testing.*
-import io.mockk.coEvery
-import io.mockk.mockk
 import no.nav.helse.dusseldorf.testsupport.jws.Azure
-import no.nav.omsorgsdager.ApplicationContext
-import no.nav.omsorgsdager.CorrelationId
-import no.nav.omsorgsdager.Identitetsnummer.Companion.somIdentitetsnummer
+import no.nav.omsorgsdager.*
 import no.nav.omsorgsdager.Json.Companion.somJson
-import no.nav.omsorgsdager.omsorgsdager
 import no.nav.omsorgsdager.testutils.ApplicationContextExtension
-import no.nav.omsorgsdager.testutils.ApplicationContextExtension.Companion.buildStarted
-import no.nav.omsorgsdager.testutils.somMocketOmsorgspengerSaksnummer
-import no.nav.omsorgsdager.tid.Periode
-import no.nav.omsorgsdager.vedtak.dto.*
-import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
-import java.time.LocalDate
-import java.time.ZonedDateTime
 import kotlin.test.assertEquals
-import kotlin.test.assertNull
 
 @ExtendWith(ApplicationContextExtension::class)
 internal class InnvilgedeVedtakApisTest(
-    applicationContextBuilder: ApplicationContext.Builder) {
+    applicationContextBuilder: ApplicationContext.Builder) : InnvilgedeVedtakKontrakt(applicationContextBuilder) {
 
-    private val applicationContext = applicationContextBuilder.also {
-        it.innvilgedeVedtakService = mockk<InnvilgedeVedtakService>().also {
-            coEvery { it.hentInnvilgedeVedtak(eq(IdentitetsnummerUtenVedtak.somIdentitetsnummer()), any(), any()) }.returns(InnvilgedeVedtak(emptyList()))
-            coEvery { it.hentInnvilgedeVedtak(eq(IdentitetsnummerMedToAvHver.somIdentitetsnummer()), any(), any()) }.returns(InnvilgedeVedtak(
-                kroniskSyktBarn = listOf(
-                    KroniskSyktBarnInnvilgetVedtak(barn = Barn(identitetsnummer = IdentitetsnummerBarn1, fødselsdato = LocalDate.parse("2020-01-01"), omsorgspengerSaksnummer = IdentitetsnummerBarn1.somMocketOmsorgspengerSaksnummer()), tidspunkt = ZonedDateTime.parse("2020-11-10T12:00:00.00Z"), periode = Periode("2020-01-01/2020-12-31"), kilder = setOf(Kilde(id ="1", type = "K9-Sak"))),
-                    KroniskSyktBarnInnvilgetVedtak(barn = Barn(identitetsnummer = null, fødselsdato = LocalDate.parse("2019-01-01")), tidspunkt = ZonedDateTime.parse("2021-02-19T23:30:00.00Z"), periode = Periode("2018-01-01/2025-12-31"), kilder = setOf(Kilde(id ="1", type = "Infotrygd")))
-                ),
-                midlertidigAlene = listOf(
-                    MidlertidigAleneInnvilgetVedtak(tidspunkt = ZonedDateTime.parse("1999-11-10T12:00:00.00Z"), periode = Periode(LocalDate.parse("2005-01-01")), kilder = setOf(Kilde(id = "3", type = "Infotrygd"))),
-                    MidlertidigAleneInnvilgetVedtak(tidspunkt = ZonedDateTime.parse("2020-11-10T12:00:00.00Z"), periode = Periode("2020-05-05/2030-03-03"), kilder = setOf(Kilde(id = "4", type = "K9-Sak")))
-                )
-            ))
-
+    override fun hentInnvilgedeVedtak(jsonRequest: Json): Json {
+        return withTestApplication({ omsorgsdager(applicationContext) }) {
+            this.hentInnvilgedeVedtak(
+                jsonRequest = jsonRequest
+            ).second!!
         }
-    }.buildStarted()
+    }
 
     @Test
     fun `Ingen authorization header`() {
         withTestApplication({ omsorgsdager(applicationContext) }) {
-            hentOgAssertInnvilgedeVedtak(
-                identitetsnummer = IdentitetsnummerUtenVedtak,
-                authorizationHeader = null,
-                forventetHttpStatusCode = HttpStatusCode.Unauthorized
+            val actual = hentInnvilgedeVedtak(
+                jsonRequest = requestUtenVedtak(),
+                authorizationHeader = null
             )
+            assertEquals(HttpStatusCode.Unauthorized to null, actual)
         }
     }
 
     @Test
     fun `Ikke autorisert system`() {
         withTestApplication({ omsorgsdager(applicationContext) }) {
-            hentOgAssertInnvilgedeVedtak(
-                identitetsnummer = IdentitetsnummerUtenVedtak,
+            val actual = hentInnvilgedeVedtak(
+                jsonRequest = requestUtenVedtak(),
                 authorizationHeader = Azure.V2_0.generateJwt(
                     clientId = "k9-sak",
                     audience = "omsorgsdager",
                     accessAsApplication = false
-                ).let { "Bearer $it" },
-                forventetHttpStatusCode = HttpStatusCode.Forbidden,
-                forventetResponse = ForventetResponseForbidden
+                ).let { "Bearer $it" }
             )
+            assertEquals(HttpStatusCode.Forbidden to ForventetResponseForbidden, actual)
         }
-    }
-
-    @Test
-    fun `Ikke autorisert bruker`() {
     }
 
     @Test
     fun `Ugyldig request`() {
         withTestApplication({ omsorgsdager(applicationContext) }) {
-            hentOgAssertInnvilgedeVedtak(
-                identitetsnummer = "identitetsnummer",
-                fom = "tom",
-                tom = "tom",
-                forventetHttpStatusCode = HttpStatusCode.BadRequest
+            val actual = hentInnvilgedeVedtak(
+                jsonRequest = InnvilgedeVedtakRequest(
+                    fom = "fom",
+                    tom = "tom",
+                    identitetsnummer = "identitetsnummer"
+                ).jsonRequest
             )
+            assertEquals(HttpStatusCode.BadRequest to null, actual)
         }
     }
-
-    @Test
-    fun `Person som ikke har vedtak`() {
-        withTestApplication({ omsorgsdager(applicationContext) }) {
-            hentOgAssertInnvilgedeVedtak(
-                identitetsnummer = IdentitetsnummerUtenVedtak,
-                forventetResponse = ForventetResponseUtenVedtak
-            )
-        }
-    }
-
-    @Test
-    fun `Person som ikke har 2 av hvert vedtak`() {
-        @Language("JSON")
-        val forventetResponse = """
-        {
-            "kroniskSyktBarn": [{
-                "barn": {
-                    "identitetsnummer": "11111111111",
-                    "fødselsdato": "2020-01-01",
-                    "omsorgspengerSaksnummer": "OP11111111111"
-                },
-                "kilder": [{
-                    "id": "1",
-                    "type": "K9-Sak"
-                }],
-                "vedtatt": "2020-11-10",
-                "gyldigFraOgMed": "2020-01-01",
-                "gyldigTilOgMed": "2020-12-31"
-            }, {
-                "barn": {
-                    "identitetsnummer": null,
-                    "fødselsdato": "2019-01-01",
-                    "omsorgspengerSaksnummer": null
-                },
-                "kilder": [{
-                    "id": "1",
-                    "type": "Infotrygd"
-                }],
-                "vedtatt": "2021-02-20",
-                "gyldigFraOgMed": "2018-01-01",
-                "gyldigTilOgMed": "2025-12-31"
-            }],
-            "midlertidigAlene": [{
-                "kilder": [{
-                    "id": "3",
-                    "type": "Infotrygd"
-                }],
-                "vedtatt": "1999-11-10",
-                "gyldigFraOgMed": "2005-01-01",
-                "gyldigTilOgMed": "2005-01-01"
-            }, {
-                "kilder": [{
-                    "id": "4",
-                    "type": "K9-Sak"
-                }],
-                "vedtatt": "2020-11-10",
-                "gyldigFraOgMed": "2020-05-05",
-                "gyldigTilOgMed": "2030-03-03"
-            }]
-        }
-        """.trimIndent()
-        withTestApplication({ omsorgsdager(applicationContext) }) {
-            hentOgAssertInnvilgedeVedtak(
-                identitetsnummer = IdentitetsnummerMedToAvHver,
-                forventetResponse = forventetResponse
-            )
-        }
-    }
-
 
     private companion object {
-        val IdentitetsnummerBarn1 = "11111111111".somIdentitetsnummer()
-        val IdentitetsnummerMedToAvHver = "29099011110"
-        val IdentitetsnummerUtenVedtak = "29099011111"
-        val ForventetResponseUtenVedtak = """{"kroniskSyktBarn": [], "midlertidigAlene": []}"""
-        val ForventetResponseForbidden = """{"detail":"Requesten inneholder ikke tilstrekkelige tilganger.","instance":"about:blank","type":"/problem-details/unauthorized","title":"unauthorized","status":403}"""
+        val ForventetResponseForbidden = """{"detail":"Requesten inneholder ikke tilstrekkelige tilganger.","instance":"about:blank","type":"/problem-details/unauthorized","title":"unauthorized","status":403}""".somJson()
 
-        fun TestApplicationEngine.hentOgAssertInnvilgedeVedtak(
-            identitetsnummer: String,
-            fom: String = "2021-01-01",
-            tom: String = "2021-12-31",
+        fun TestApplicationEngine.hentInnvilgedeVedtak(
+            jsonRequest: Json,
             authorizationHeader: String? = Azure.V2_0.generateJwt(
                 clientId = "k9-aarskvantum",
                 audience = "omsorgsdager",
                 accessAsApplication = true
-            ).let { "Bearer $it" },
-            forventetHttpStatusCode: HttpStatusCode = HttpStatusCode.OK,
-            forventetResponse: String? = null
-        ) {
-            with(this) {
+            ).let { "Bearer $it" }) : Pair<HttpStatusCode, Json?> {
+            return with(this) {
                 handleRequest(HttpMethod.Post, "/api/innvilgede-vedtak-utvidet-rett") {
-                    @Language("JSON")
-                    val body = """
-                        {
-                          "identitetsnummer": "$identitetsnummer",
-                          "fom": "$fom",
-                          "tom": "$tom"
-                        }
-                    """.trimIndent()
                     authorizationHeader?.let {
                         addHeader(HttpHeaders.Authorization, authorizationHeader)
                     }
                     addHeader(HttpHeaders.XCorrelationId, "${CorrelationId.genererCorrelationId()}")
                     addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
                     addHeader(HttpHeaders.Accept, ContentType.Application.Json.toString())
-                    setBody(body)
-                }.apply {
-                    assertEquals(forventetHttpStatusCode, response.status())
-                    if (forventetResponse == null) {
-                        assertNull(response.content)
-                    } else {
-                        assertEquals(forventetResponse.somJson(), response.content!!.somJson())
-                    }
+                    setBody(jsonRequest.raw)
+                }.let {
+                    it.response.status()!! to it.response.content?.somJson()
                 }
             }
         }

--- a/app/src/test/kotlin/no/nav/omsorgsdager/vedtak/InnvilgedeVedtakKontrakt.kt
+++ b/app/src/test/kotlin/no/nav/omsorgsdager/vedtak/InnvilgedeVedtakKontrakt.kt
@@ -1,0 +1,124 @@
+package no.nav.omsorgsdager.vedtak
+
+import io.mockk.coEvery
+import io.mockk.mockk
+import no.nav.omsorgsdager.ApplicationContext
+import no.nav.omsorgsdager.Identitetsnummer
+import no.nav.omsorgsdager.Identitetsnummer.Companion.somIdentitetsnummer
+import no.nav.omsorgsdager.Json
+import no.nav.omsorgsdager.Json.Companion.somJson
+import no.nav.omsorgsdager.testutils.ApplicationContextExtension.Companion.buildStarted
+import no.nav.omsorgsdager.testutils.somMocketOmsorgspengerSaksnummer
+import no.nav.omsorgsdager.tid.Periode
+import no.nav.omsorgsdager.vedtak.dto.*
+import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.time.ZonedDateTime
+import kotlin.test.assertEquals
+
+internal data class InnvilgedeVedtakRequest(
+    private val identitetsnummer: String,
+    private val fom: String,
+    private val tom: String) {
+    constructor(identitetsnummer: Identitetsnummer, periode: Periode) : this(
+        identitetsnummer = "$identitetsnummer",
+        fom = "${periode.fom}",
+        tom = "${periode.tom}"
+    )
+    internal val jsonRequest = """{ "fom": "$fom", "tom": "$tom", "identitetsnummer": "$identitetsnummer"}""".trimIndent().somJson()
+}
+internal abstract class InnvilgedeVedtakKontrakt(
+    applicationContextBuilder: ApplicationContext.Builder) {
+
+
+    protected val applicationContext = applicationContextBuilder.also {
+        it.innvilgedeVedtakService = mockk<InnvilgedeVedtakService>().also {
+            coEvery { it.hentInnvilgedeVedtak(eq(IdentitetsnummerUtenVedtak), any(), any()) }.returns(InnvilgedeVedtak(emptyList()))
+            coEvery { it.hentInnvilgedeVedtak(eq(IdentitetsnummerMedToAvHver), any(), any()) }.returns(InnvilgedeVedtak(
+                kroniskSyktBarn = listOf(
+                    KroniskSyktBarnInnvilgetVedtak(barn = Barn(identitetsnummer = IdentitetsnummerBarn1, fødselsdato = LocalDate.parse("2020-01-01"), omsorgspengerSaksnummer = IdentitetsnummerBarn1.somMocketOmsorgspengerSaksnummer()), tidspunkt = ZonedDateTime.parse("2020-11-10T12:00:00.00Z"), periode = Periode("2020-01-01/2020-12-31"), kilder = setOf(Kilde(id ="1", type = "K9-Sak"))),
+                    KroniskSyktBarnInnvilgetVedtak(barn = Barn(identitetsnummer = null, fødselsdato = LocalDate.parse("2019-01-01")), tidspunkt = ZonedDateTime.parse("2021-02-19T23:30:00.00Z"), periode = Periode("2018-01-01/2025-12-31"), kilder = setOf(Kilde(id ="1", type = "Infotrygd")))
+                ),
+                midlertidigAlene = listOf(
+                    MidlertidigAleneInnvilgetVedtak(tidspunkt = ZonedDateTime.parse("1999-11-10T12:00:00.00Z"), periode = Periode(LocalDate.parse("2005-01-01")), kilder = setOf(Kilde(id = "3", type = "Infotrygd"))),
+                    MidlertidigAleneInnvilgetVedtak(tidspunkt = ZonedDateTime.parse("2020-11-10T12:00:00.00Z"), periode = Periode("2020-05-05/2030-03-03"), kilder = setOf(Kilde(id = "4", type = "K9-Sak")))
+                )
+            ))
+
+        }
+    }.buildStarted()
+
+    @Test
+    fun `Person som ikke har vedtak`() {
+        assertEquals(ForventetResponseUtenVedtak, hentInnvilgedeVedtak(RequestUtenVedtak))
+    }
+
+    @Test
+    fun `Person som ikke har 2 av hvert vedtak`() {
+        assertEquals(ForventetResponseMedToAvHver, hentInnvilgedeVedtak(RequestMedToAvHver))
+    }
+
+    abstract fun hentInnvilgedeVedtak(jsonRequest: Json) : Json
+    protected fun requestUtenVedtak() = RequestUtenVedtak
+
+    protected companion object {
+        private val IdentitetsnummerBarn1 = "11111111111".somIdentitetsnummer()
+
+        protected val IdentitetsnummerUtenVedtak = "29099011111".somIdentitetsnummer()
+        private val RequestUtenVedtak = InnvilgedeVedtakRequest(identitetsnummer = IdentitetsnummerUtenVedtak, periode = Periode(2021)).jsonRequest
+        private val ForventetResponseUtenVedtak = """{"kroniskSyktBarn": [], "midlertidigAlene": []}""".somJson()
+
+        private val IdentitetsnummerMedToAvHver = "29099011110".somIdentitetsnummer()
+        private val RequestMedToAvHver = InnvilgedeVedtakRequest(identitetsnummer = IdentitetsnummerMedToAvHver, periode = Periode(2021)).jsonRequest
+        @Language("JSON")
+        private val ForventetResponseMedToAvHver = """
+        {
+            "kroniskSyktBarn": [{
+                "barn": {
+                    "identitetsnummer": "11111111111",
+                    "fødselsdato": "2020-01-01",
+                    "omsorgspengerSaksnummer": "OP11111111111"
+                },
+                "kilder": [{
+                    "id": "1",
+                    "type": "K9-Sak"
+                }],
+                "vedtatt": "2020-11-10",
+                "gyldigFraOgMed": "2020-01-01",
+                "gyldigTilOgMed": "2020-12-31"
+            }, {
+                "barn": {
+                    "identitetsnummer": null,
+                    "fødselsdato": "2019-01-01",
+                    "omsorgspengerSaksnummer": null
+                },
+                "kilder": [{
+                    "id": "1",
+                    "type": "Infotrygd"
+                }],
+                "vedtatt": "2021-02-20",
+                "gyldigFraOgMed": "2018-01-01",
+                "gyldigTilOgMed": "2025-12-31"
+            }],
+            "midlertidigAlene": [{
+                "kilder": [{
+                    "id": "3",
+                    "type": "Infotrygd"
+                }],
+                "vedtatt": "1999-11-10",
+                "gyldigFraOgMed": "2005-01-01",
+                "gyldigTilOgMed": "2005-01-01"
+            }, {
+                "kilder": [{
+                    "id": "4",
+                    "type": "K9-Sak"
+                }],
+                "vedtatt": "2020-11-10",
+                "gyldigFraOgMed": "2020-05-05",
+                "gyldigTilOgMed": "2030-03-03"
+            }]
+        }
+        """.trimIndent().somJson()
+    }
+}

--- a/app/src/test/kotlin/no/nav/omsorgsdager/vedtak/InnvilgedeVedtakRiverTest.kt
+++ b/app/src/test/kotlin/no/nav/omsorgsdager/vedtak/InnvilgedeVedtakRiverTest.kt
@@ -1,0 +1,52 @@
+package no.nav.omsorgsdager.vedtak
+
+import no.nav.helse.rapids_rivers.testsupport.TestRapid
+import no.nav.k9.rapid.behov.Behov
+import no.nav.k9.rapid.behov.Behovssekvens
+import no.nav.omsorgsdager.*
+import no.nav.omsorgsdager.Json.Companion.somJson
+import no.nav.omsorgsdager.testutils.ApplicationContextExtension
+import no.nav.omsorgsdager.testutils.sisteMeldingHarLøsningPå
+import no.nav.omsorgsdager.testutils.sisteMeldingSomJSONObject
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(ApplicationContextExtension::class)
+internal class InnvilgedeVedtakRiverTest(
+    applicationContextBuilder: ApplicationContext.Builder) : InnvilgedeVedtakKontrakt(applicationContextBuilder) {
+
+    private val rapid = TestRapid().also {
+        it.registerApplicationContext(applicationContext)
+    }
+
+    override fun hentInnvilgedeVedtak(jsonRequest: Json): Json {
+        val behovssekvens = behovssekvens(jsonRequest)
+        rapid.sendTestMessage(behovssekvens)
+        rapid.sisteMeldingHarLøsningPå(Behov)
+        return rapid.løsningJson()
+    }
+
+    @Test
+    fun `ugyldig behov`() {
+        val behovssekvens = behovssekvens(Json.tomJson())
+        rapid.sendTestMessage(behovssekvens)
+        assertEquals(0, rapid.inspektør.size)
+    }
+
+    private companion object {
+        const val Behov = "HentUtvidetRettVedtakV2"
+        fun behovssekvens(
+            jsonRequest: Json
+        ) = Behovssekvens(
+            id = "${BehovssekvensId.genererBehovssekvensId()}",
+            correlationId = "${CorrelationId.genererCorrelationId()}",
+            behov = arrayOf(Behov(navn = Behov, input = jsonRequest.map))
+        ).keyValue.second
+
+        fun TestRapid.løsningJson() = sisteMeldingSomJSONObject()
+            .getJSONObject("@løsninger")
+            .getJSONObject(Behov)
+            .also { it.remove("løst") }.somJson()
+    }
+}

--- a/app/src/test/kotlin/no/nav/omsorgsdager/vedtak/InnvilgedeVedtakServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/omsorgsdager/vedtak/InnvilgedeVedtakServiceTest.kt
@@ -92,7 +92,7 @@ internal class InnvilgedeVedtakServiceTest(
         applicationContext.behandlingService.lagre(behandling1, parter)
         applicationContext.behandlingService.lagre(behandling2, parter)
         applicationContext.behandlingService.lagre(behandling3, parter)
-        applicationContext.behandlingService.lagre(behandling4, parter) // Denne skal ikke ha noen innvirkning på re sultatet ettersom tidspunktet er satt før både vedtatt i Infotrygd & før andre behandligner i K9-Sak
+        applicationContext.behandlingService.lagre(behandling4, parter) // Denne skal ikke ha noen innvirkning på resultatet ettersom tidspunktet er satt før både vedtatt i Infotrygd & før andre behandligner i K9-Sak
 
         val innvilgedeVedtakKroniskSyktBarn = hentInnvilgedeVedtak("11111111111".somIdentitetsnummer(), Periode("2020-01-01/2050-01-01")).kroniskSyktBarn
 


### PR DESCRIPTION
- Strukturerte om API-test til å arve `InnvilgedeVedtakKontrakt` (uten endringer i API'et eller testene)
- Implementerte River-test til også å arve `InnvilgedeVedtakKontrakt` slik at API'et og River har samme kontrakt. Med andre ord får man det samme om man kaller sync mot API eller async på River.